### PR TITLE
Clarifies use of handleTruncate and useJsOnly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "6"
 
 sudo: false
 dist: trusty

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This Ember addon provides a component for truncating/clamping text.
 
 * Note: This component currently does not support block form.
 
-## Intallation
+## Installation
 
 * `npm install ember-line-clamp`
 
@@ -72,7 +72,7 @@ Default: `...`
 {{line-clamp
   text="A really long text to truncate"
   lines=2
-  ellipsis="~"
+  ellipsis="..."
 }}
 ```
 
@@ -86,20 +86,6 @@ Default: `true`
 {{line-clamp
   text="A really long text to truncate"
   interactive=false
-}}
-```
-
-### `useJsOnly`
-
-Some users for some unknown reason might like to disable the native CSS solution when available, we want to keep them happy.
-
-Default: `false`
-
-```handlebars
-{{line-clamp
-  text="A really long text to truncate"
-  interactive=false
-  useJsOnly=true
 }}
 ```
 
@@ -175,7 +161,7 @@ Default: `See Less`
 
 ### `onExpand`
 
-This attribuet allows you to pass an action/closure to trigger when text is expanded
+This attribute allows you to pass an action/closure to trigger when text is expanded
 
 ```handlebars
 {{line-clamp
@@ -186,7 +172,7 @@ This attribuet allows you to pass an action/closure to trigger when text is expa
 
 ### `onCollapse`
 
-This attribuet allows you to pass an action/closure to trigger when text is collapsed
+This attribute allows you to pass an action/closure to trigger when text is collapsed
 
 ```handlebars
 {{line-clamp
@@ -196,17 +182,51 @@ This attribuet allows you to pass an action/closure to trigger when text is coll
 }}
 ```
 
-### `handleTruncate`
+### `useJsOnly`
 
-This attribuet allows you to pass an action/closure to trigger everytime the text goes through the truncation procedure, receives a boolean to determine if text was truncated
+This attribute allows you to ensure `handleTruncate` is called all the time. The caveat is the browser native CSS solutions will never be used. Note: When the browser native CSS solutions are used, `handleTruncate` is never called.
+
+Default: `false`
 
 ```handlebars
 {{line-clamp
   text="A really long text to truncate"
-  onExpand=doSomethingWhenTextIsExpanded
-  onCollapse=(action "doSomethingWhenTextIsCollapsed")
+  useJsOnly=true
   handleTruncate=(action "onHandleTruncate")
 }}
+```
+
+### `handleTruncate`
+
+This attribute allows you to pass an action/closure to trigger every time the text goes through the truncation process, receives a boolean to determine if the text was truncated. Not called when the browser native CSS solutions are used.
+
+```handlebars
+{{line-clamp
+  text="A really long text to truncate"
+  handleTruncate=(action "onHandleTruncate")
+}}
+```
+
+Note: Will not execute when the native CSS line-clamp is used because there is no good way currently to tell whether the browser actually truncated the text or not. If you need `handleTruncate` to run all the time, please enable `useJsOnly`.
+
+```handlebars
+{{line-clamp
+  text="A really long text to truncate"
+  useJsOnly=true
+  handleTruncate=(action "onHandleTruncate")
+}}
+```
+
+Then create an action that gets notified after the text is truncated. When the text is truncated and ellipsis applied, `didTruncate` will be `true`. When the text isn't truncated, `didTruncate` will be `false`. 
+
+```handlebars
+actions: {
+  onHandleTruncate(didTruncate) {
+    if(didTruncate) {
+      this.set('someProperty', true);
+    }
+  }
+}
 ```
 
 ## Dev TODOs
@@ -220,4 +240,3 @@ This attribuet allows you to pass an action/closure to trigger everytime the tex
 * [CSS Line Clamping](http://guerillalabs.co/blog/css-line-clamping.html) article
 * [@nilsynils](https://github.com/nilsynils) for his [Medium Post](https://medium.com/mofed/css-line-clamp-the-good-the-bad-and-the-straight-up-broken-865413f16e5)
 * [@One-com](https://github.com/One-com) for a [inspiration](https://github.com/One-com/react-truncate)
-

--- a/addon/components/line-clamp.js
+++ b/addon/components/line-clamp.js
@@ -51,7 +51,6 @@ const HTML_ENTITIES_TO_CHARS = {
  * @param {Boolean} stripText @default false Enable stripping <br> tags when using native css line-clamp
  * @param {String}  ellipsis @default '...' Characters to be used as ellipsis
  * @param {Boolean} interactive @default true Enable see more/see less functionality
- * @param {Boolean} useJsOnly @default false Disable native CSS solution
  * @param {Boolean} truncate @default true Allow managing truncation from outside component
  * @param {Boolean} showMoreButton @default true
  * @param {Boolean} showLessButton @default true
@@ -59,7 +58,8 @@ const HTML_ENTITIES_TO_CHARS = {
  * @param {String}  seeLessText @default 'See Less'
  * @param {Action}  onExpand Action triggered when text is expanded
  * @param {Action}  onCollapse Action triggered when text is collapsed
- * @param {Action}  handleTruncate Action triggered every time text does get truncated/clamped
+ * @param {Boolean} useJsOnly @default false Disables native CSS solution
+ * @param {Action}  handleTruncate @returns {boolean} didTruncate Action triggered every time text goes true truncation process. Only called when native CSS solution isn't used. If didTruncate is true, text truncated and ellipsis applied.
  *
  * @example
  * ```


### PR DESCRIPTION
Hi @lstrrs! Hi Folks!

UPDATE:
A combination of the existing `handleTruncate` and `useJsOnly` allowed us to get the same results we were looking for with creating the potential `onEllipsis` callback here.

Refactored the PR to clarify the use of handleTruncate and useJsOnly. See, updated README:
https://github.com/lstrrs/ember-line-clamp/blob/ee1500bbd44e79c9c25d7a70c7bdfd1ca31c923f/README.md

. . .

ORIGINAL PR DESCRIPTION:
PR adds user defined action onEllipsis. `onEllipsis` Action triggered when ellipsis is applied.

**Usage:**
```
{{line-clamp
  text="A really long text to truncate"
  useJsOnly=true
  onEllipsis=(action "doSomethingWhenEllipsisIsAppliedToText")
}}
```

**Background:**
This update enables teams to enhance their applications with further UI/UX signals by triggering a user defined function when an ellipsis is actually applied to text overflow. Here, we needed to show an extra expand/collapse chevron on hover when `ember-line-clamp` determines the large abstract text runs more than three lines.

![ember-line-clamp-oneellipsis-demo](https://user-images.githubusercontent.com/376230/45768453-e277d880-bc0a-11e8-9e8f-addc7ee6a4c3.gif)

When text `needsEllipsis`,  we now have access to `onEllipsis` callback in our application  for further UI/UX enhancements.

**Note(s):**
`onEllipsis` currently requires `useJsOnly` enabled because there doesn't seem to yet be a good way to tap into the native CSS `-webkit-line-clamp` (for multiple lines) or the native CSS `text-overflow` (for a single line) to determine whether the browser actually applied an ellipsis to the text without using JavaScript.

**Pros/Cons:**
- Con: Not able to use with the native CSS approach(s). 
- Pro: The ability to add UI/UX application enhancements when an ellipsis is actually applied to text.

