### PR TITLE
remove setting _oldTruncate in init to allow an initial non-truncated…

### DIFF
--- a/addon/components/line-clamp.js
+++ b/addon/components/line-clamp.js
@@ -255,8 +255,6 @@ export default Component.extend({
   init() {
     this._super(...arguments);
 
-    this.set('_oldTruncate', this.get('truncate'));
-
     // interative prop overpowers showMoreButton and showLessButton when false
     this._showMoreButton = this.interactive && this.showMoreButton;
     this._showLessButton = this.interactive && this.showLessButton;

--- a/tests/integration/components/line-clamp-test.js
+++ b/tests/integration/components/line-clamp-test.js
@@ -68,7 +68,7 @@ test('inline form works as expeted', function(assert) {
   );
 
   assert.equal(
-    ellipsisElement.innerText,
+    ellipsisElement.innerText.trim(),
     '... See More',
     'Ellipsis element contains expetend ellipsis and see more text'
   );
@@ -176,7 +176,7 @@ test('ellipsis attribute works as expected', function(assert) {
   );
 
   assert.equal(
-    ellipsisElement.innerText,
+    ellipsisElement.innerText.trim(),
     '- See More',
     'Ellipsis element contains expetend ellipsis and see more text'
   );
@@ -698,6 +698,40 @@ test('truncation can be controlled via the truncate attribute', function(assert)
   );
 });
 
+test('initial truncation can be controlled via the truncate attribute (false case)', function (assert) {
+  assert.expect(3);
+
+  this.set('textToTruncate', 'helloworld helloworld helloworld helloworld helloworld helloworld helloworld helloworld');
+  this.set('truncate', false);
+
+  this.render(hbs`<div id="test-conatiner" style="width: 300px; font-size: 16px; font-family: sans-serif;">
+    {{line-clamp
+      text=textToTruncate
+      truncate=truncate
+    }}
+  </div>`);
+
+  const element = this.$()[0];
+  assert.equal(
+    element.innerText.trim(),
+    'helloworld helloworld helloworld helloworld helloworld helloworld helloworld helloworld See Less'
+  );
+
+  this.set('truncate', false);
+
+  assert.equal(
+    element.innerText.trim(),
+    'helloworld helloworld helloworld helloworld helloworld helloworld helloworld helloworld See Less'
+  );
+
+  this.set('truncate', true);
+
+  assert.equal(
+    element.innerText.trim(),
+    'helloworld helloworld helloworld helloworld hellowor... See More'
+  );
+});
+
 test('stripText correctly strips <br> tags', function(assert) {
   assert.expect(2);
 
@@ -748,8 +782,8 @@ test('stripText correctly strips preserves newlines when stripText is false', fu
   const element = this.$()[0];
   assert.equal(
     element.innerText.trim(),
-    `helloworld 
-helloworld 
+    `helloworld
+helloworld
 hellowor... See More`
   );
 


### PR DESCRIPTION
Right now the property `_oldTruncate` is being set to the passed value of the `truncate` property in `init()`.

Then, in `didReceiveAttrs()` it is checking whether `_oldTruncate !== truncate`. This will **always** evaluate to false during the first pass of `didReceiveAttrs` because it was just set. Due to this, the passed value of `truncate` is ignored and the default behavior occurs (which is to do the truncation).

Because of the behavior of the above, passing `false` as the initial value of `truncate` will have no effect, at least until it is changed.


Note: the unrelated tests that were updated were failing before any changes that were made. If advisable I can remove those changes, but they were the only way the tests would all pass for me.