### PR TITLE
FIX | Preserve visual newlines in extended full text

### DIFF
--- a/addon/templates/components/line-clamp.hbs
+++ b/addon/templates/components/line-clamp.hbs
@@ -18,7 +18,7 @@
 {{else if _strippedText}}
   {{_strippedText}}
 {{else}}
-  {{text}}
+  <span class="lt-line-clamp__raw-line">{{text}}</span>
 {{/each}}
 
 {{#if _showLessButton}}

--- a/vendor/ember-line-clamp/vendor.css
+++ b/vendor/ember-line-clamp/vendor.css
@@ -23,3 +23,7 @@
   /*! autoprefixer: on */
   text-overflow: ellipsis;
 }
+
+.lt-line-clamp__raw-line {
+  white-space: pre-line;
+}


### PR DESCRIPTION
Previously, newlines in the full text were not respected visually. While present in the html, the full text didn't show newlines because of the default value of the css "white-space" rule. This RB gives full text the "white-space: pre-line;" rule, which preserves newlines.

The behavior of stripText, which should apply only to the clamped version of the text, is unaffected.

[Videos of behavior before and after](https://www.dropbox.com/sh/xw6euvtm6cww16a/AAALyK6UnsD5BrSId98kyJMUa?dl=0)
