### PR TITLE
Avoid exception when `text` is undefined

### DIFF
--- a/addon/components/line-clamp.js
+++ b/addon/components/line-clamp.js
@@ -473,7 +473,7 @@ export default Component.extend({
    * @private
    */
   _stripBrTags(text) {
-    return text.toString().replace(/<br.*?[/]?>/gi, ' ').replace(/\r\n|\n|\r/g, ' ');
+    return String(text).replace(/<br.*?[/]?>/gi, ' ').replace(/\r\n|\n|\r/g, ' ');
   },
 
   /**
@@ -483,7 +483,7 @@ export default Component.extend({
    * @private
    */
   _convertBrTags(text) {
-    return text.toString().replace(/<br.*?[/]?>/gi, '\n');
+    return String(text).replace(/<br.*?[/]?>/gi, '\n');
   },
 
   /**
@@ -494,7 +494,7 @@ export default Component.extend({
    * @private
    */
   _unescapeText(text) {
-    return text.toString().replace(R_ENTITIES, match =>
+    return String(text).replace(R_ENTITIES, match =>
       HTML_ENTITIES_TO_CHARS[match] ||
       HTML_ENTITIES_TO_CHARS[match.replace(
         /([0-9]+)/gi,


### PR DESCRIPTION
Hi Luis, thanks for you handle library.

Our CI tests failed because missing mock data for the text property. Not sure if
this would happen often in real usage, but on the theory `line-clamp` should not
throw on bad input, I made a small change to handle the situation.