### PR TITLE
[ember-strict-resolver] ensure that services are looked up without camelCase

### DIFF
--- a/addon/components/line-clamp.js
+++ b/addon/components/line-clamp.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { inject } from '@ember/service';
+import { inject as service } from '@ember/service';
 import layout from '../templates/components/line-clamp';
 import { computed } from '@ember/object';
 import { htmlSafe, isHTMLSafe } from '@ember/string';
@@ -72,7 +72,7 @@ const HTML_ENTITIES_TO_CHARS = {
 export default Component.extend({
   layout,
 
-  unifiedEventHandler: inject(),
+  unifiedEventHandler: service('unified-event-handler'),
 
   componentName: 'LineClamp',
 


### PR DESCRIPTION
ember-strict-resolver is currently being onboarded to our application https://github.com/stefanpenner/ember-strict-resolver. It requires that service lookups are using the non-camel case. By default inject() will use the same value as the variable definition. So 

```js
unifiedEventHandler: inject() === unifiedEventHandler: inject('unifiedEventHandler')
```