### PR TITLE
Update lastLine to support google translate(for issue #48)

### DIFF
--- a/addon/templates/components/line-clamp.hbs
+++ b/addon/templates/components/line-clamp.hbs
@@ -3,7 +3,8 @@
     <span class="lt-line-clamp__line lt-line-clamp__line--last">
       {{unbound line.text}}
       {{~#if line.needsEllipsis~}}
-        <span class="lt-line-clamp__ellipsis">{{unbound ellipsis}}
+        <span class="lt-line-clamp__ellipsis"><div class="lt-line-clamp__dummy-element">{{unbound ellipsis}}</div>
+        {{!-- Use div to wrap the ellipsis up so that the see more button can work after google translates the page (Issue #48)--}}
           {{#if _showMoreButton}}
             <a data-test-line-clamp-show-more-button="true" href="#" role="button" id="line-clamp-show-more-button" aria-expanded="false" class="lt-line-clamp__more" onclick={{action "toggleTruncate"}}>{{unbound seeMoreText}}</a>
           {{/if}}

--- a/tests/integration/components/line-clamp-test.js
+++ b/tests/integration/components/line-clamp-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | line clamp', function(hooks) {
     const lastLine = lines[lines.length - 1];
     const lastLineChildren = lastLine.children;
     const ellipsisElement = lastLineChildren[0];
-    const seeMoreButton = ellipsisElement.children[0];
+    const seeMoreButton = ellipsisElement.children[1];
     const dummyEllipsis = element.querySelectorAll('.lt-line-clamp--dummy');
 
     assert.ok(
@@ -291,7 +291,7 @@ module('Integration | Component | line clamp', function(hooks) {
     const lastLine = lines[lines.length - 1];
     const lastLineChildren = lastLine.children;
     const ellipsisElement = lastLineChildren[0];
-    const seeMoreButton = ellipsisElement.children[0];
+    const seeMoreButton = ellipsisElement.children[1];
 
     assert.ok(
       element,
@@ -333,7 +333,7 @@ module('Integration | Component | line clamp', function(hooks) {
     const lastLine = lines[lines.length - 1];
     const lastLineChildren = lastLine.children;
     const ellipsisElement = lastLineChildren[0];
-    const seeMoreButton = ellipsisElement.children[0];
+    const seeMoreButton = ellipsisElement.children[1];
 
     assert.ok(
       element,
@@ -419,7 +419,7 @@ module('Integration | Component | line clamp', function(hooks) {
     const lastLine = lines[lines.length - 1];
     const lastLineChildren = lastLine.children;
     const ellipsisElement = lastLineChildren[0];
-    const seeMoreButton = ellipsisElement.children[0];
+    const seeMoreButton = ellipsisElement.children[1];
 
     assert.ok(
       element,

--- a/vendor/ember-line-clamp/vendor.css
+++ b/vendor/ember-line-clamp/vendor.css
@@ -26,3 +26,7 @@
 .lt-line-clamp__raw-line {
   white-space: pre-line;
 }
+
+.lt-line-clamp__dummy-element {
+  display: inline;
+}


### PR DESCRIPTION
This PR is proposed to support the google translate. (issue #48 )

Just moved </span>, not involving see more button in lt-line-clamp__ellipsis.

![issue48](https://user-images.githubusercontent.com/72173888/95147987-25943e00-0737-11eb-98cb-953cfd1d5737.gif)
