### PR TITLE
Support for textSuffix and forceEvaluate flags

### DIFF
--- a/addon/components/line-clamp.js
+++ b/addon/components/line-clamp.js
@@ -534,8 +534,6 @@ export default Component.extend({
 		const textSuffixWidth = this._measureWidth(this.textSuffix);
 		const textSuffixLength = this.textSuffix.length;
 
-		debugger;
-
     for (let line = 1; line <= numLines; line += 1) {
       const textWords = textLines[0];
 

--- a/addon/components/line-clamp.js
+++ b/addon/components/line-clamp.js
@@ -61,6 +61,7 @@ const HTML_ENTITIES_TO_CHARS = {
  * @param {Action}  onCollapse Action triggered when text is collapsed
  * @param {Boolean} useJsOnly @default false Disables native CSS solution
  * @param {Action}  handleTruncate @returns {boolean} didTruncate Action triggered every time text goes true truncation process. Only called when native CSS solution isn't used. If didTruncate is true, text truncated and ellipsis applied.
+ * @param {Boolean} forceEvaluate @default false Force evaluate the line clamp based on some condition
  *
  * @example
  * ```
@@ -164,14 +165,20 @@ export default Component.extend({
    */
 	seeLessText: 'See Less',
 
-
 	/**
 	 * Text suffix to append after the truncation
 	 * @type {String}
 	 * @default ""
 	 * @example: "Some sample content that is truncated now...continue"
 	 */
-	textSuffix: "",
+  textSuffix: "",
+
+  /**
+	 * Force evaluate the line clamp ?
+	 * @type {Boolean}
+	 * @default false
+	 */
+	forceEvaluate: false,
 
   /**
    * Based on showMoreButton and interactive flags
@@ -287,6 +294,12 @@ export default Component.extend({
       this._handleNewTruncateAttr(this.get('truncate'));
       this.set('_oldTruncate', this.get('truncate'));
     }
+
+    // For cases where the clamping has to be forced dynamically
+		// ex: parent container resizing, etc.,
+		if (this.get('forceEvaluate')) {
+			this.onResize();
+		}
   },
 
   didInsertElement() {

--- a/addon/templates/components/line-clamp.hbs
+++ b/addon/templates/components/line-clamp.hbs
@@ -4,10 +4,17 @@
       {{unbound line.text}}
       {{~#if line.needsEllipsis~}}
         <span class="lt-line-clamp__ellipsis">{{unbound ellipsis}}
+          {{#if textSuffix}}
+						&nbsp;<span class="lt-line-clamp__suffix">{{textSuffix}}</span>
+					{{/if}}
           {{#if _showMoreButton}}
             <a data-test-line-clamp-show-more-button="true" href="#" role="button" id="line-clamp-show-more-button" aria-expanded="false" class="lt-line-clamp__more" onclick={{action "toggleTruncate"}}>{{unbound seeMoreText}}</a>
           {{/if}}
         </span>
+      {{else}}
+				{{#if textSuffix}}
+          &nbsp;<span class="lt-line-clamp__suffix">{{textSuffix}}</span>
+        {{/if}}
       {{~/if~}}
     </span>
   {{else if line.newLine}}

--- a/tests/integration/components/line-clamp-test.js
+++ b/tests/integration/components/line-clamp-test.js
@@ -795,4 +795,67 @@ module('Integration | Component | line clamp', function(hooks) {
 
     assert.dom('[data-test-line-clamp-show-more-button]').isFocused('show more button is focused');
   });
+
+  test('text suffix works as expected', async function (assert) {
+    assert.expect(3);
+
+    // Render component
+    await render(hbs`<div style="width: 300px; font-size: 16px; font-family: sans-serif;">
+      {{line-clamp
+        text="helloworld helloworld helloworld helloworld helloworld helloworld helloworld helloworld"
+        lines=2
+        textSuffix="#ID-001"
+      }}
+    </div>`);
+
+    const element = this.element;
+    const suffixElement = element.querySelector('.lt-line-clamp__suffix');
+
+    assert.ok(element, 'line clamp target exists');
+    assert.dom(suffixElement).hasText('#ID-001');
+    assert.dom(element).containsText('#ID-001');
+  });
+
+  test('\'forceEvaluate\' flag re-triggers the width computation works as expected', async function (assert) {
+    assert.expect(4);
+    const done = assert.async();
+
+    this.set('forceEvaluate', false);
+
+    await render(hbs`<div id="test-conatiner" style="width: 300px; font-size: 16px; font-family: sans-serif;">
+      {{line-clamp
+        text="helloworld helloworld helloworld helloworld helloworld helloworld helloworld helloworld"
+        lines=3
+        forceEvaluate=forceEvaluate
+      }}
+    </div>`);
+
+    const element = this.element;
+    const linesExceptLast = Array.from(
+      element.querySelectorAll(
+        ".lt-line-clamp__line:not(.lt-line-clamp__line--last)"
+      ));
+    const contentLengthBefore = linesExceptLast.map(e => e.innerText).join().length;
+
+    assert.ok(element, 'line clamp target exists');
+    assert.equal(contentLengthBefore, 43);
+
+    // Force evaluate after width changes in the parent container
+    element.querySelector('#test-conatiner').style.width = '200px';
+    this.set('forceEvaluate', true);
+
+    setTimeout(() => {
+      const linesExceptLast = Array.from(
+        element.querySelectorAll(
+          ".lt-line-clamp__line:not(.lt-line-clamp__line--last)"
+        ));
+      const contentLengthAfter = linesExceptLast.map(e => e.innerText).join().length;
+
+      assert.notDeepEqual(contentLengthBefore, contentLengthAfter);
+      assert.equal(contentLengthAfter, 21);
+
+      done();
+    }, 100);
+  });
+
 })


### PR DESCRIPTION
Thanks for the wonderful add-on.


I would like to add **two new flags** to the add-on for enhanced usability.

**Example scenario** : A simple table that list products, where the line clamp component is used in the name column. The name columns needs to display the product id, along with the name text. Also the name column is resizable, so that ellipsis has to be recomputed based on the new width.

1. `textSuffix` --> Suffix text that can be appended after the ellipsis (before See More/See Less link)

**Example :** 
     `textSuffix` : "#ID-001"
     Rendered as : "helloWorld helloWorld ... #ID-001 [See More](url)"


2. `forceEvaluate` --> Boolean flag that the parent components can pass to re-evaluate the clamping logic.

**Example :** 
     `forceEvaluate` : false (parent container width: 300px)
      Rendered as : "helloWorld helloWorld ... [See More](url)"

   `forceEvaluate` : true (parent container width: 100px)
     Rendered as : "helloWorld ... [See More](url)"


Added test cases for each flag as well.