### PR TITLE
ensure we call super.included()

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 module.exports = {
   name: 'ember-line-clamp',
   included: function(app) {
+    this._super.included.apply(this, arguments);
     app.import('vendor/ember-line-clamp/vendor.css');
   }
 };


### PR DESCRIPTION
The `included()` hook should also call `super.included()` to ensure the addon is properly setup. This currently causes an issue with the new embroider build pipeline, in which the nested `ember-test-selector` addon is not properly `included`. I wouldn't be surprised if this also causes issues with the recent `ember-cli` per-bundle addon caching strategy.