### PR TITLE
[bugfix] inject the 'unified-event-handler' service correctly

### DIFF
--- a/addon/components/line-clamp.js
+++ b/addon/components/line-clamp.js
@@ -70,13 +70,13 @@ const HTML_ENTITIES_TO_CHARS = {
  *
  * @example
  * ```
- * {{line-clamp text="Some long text"}}
+ * <LineClamp @text="Some long text" />
  * ```
  *
  * @class LineClampComponent
  */
 export default class LineClampComponent extends Component {
-  @service unifiedEventHandler;
+  @service('unified-event-handler') unifiedEventHandler;
 
   /**
    * Text to truncate/clamp


### PR DESCRIPTION
I made a mistake in the migration, and the `unified-event-handler` service was not being injected correctly.

https://github.com/lstrrs/ember-line-clamp/commit/2e3b1aa2310d6457f37be12b4c359a1fe1f15753#diff-0873a48abb6b98b4910edfd65db2c884fa7367cf9db420b140b213e9556f46b1R79

Upgrading to this version was causing our test suite to fail. After this fix the tests are passing.


I also updated the example in the code to be current (which I also missed).