### PR TITLE
Support changing the tag name

### DIFF
--- a/addon/components/line-clamp.hbs
+++ b/addon/components/line-clamp.hbs
@@ -1,4 +1,5 @@
-<div
+{{#let (element (if @tagName @tagName "div")) as |Tag|}}
+<Tag
   class={{this._lineClampClass}}
   style={{this._lineClampStyle}}
   ...attributes
@@ -56,4 +57,5 @@
       {{/if}}
     {{/unless}}
   {{/if}}
-</div>
+</Tag>
+{{/let}}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ember-batcher": "^5.0.0",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.1.1",
+    "ember-element-helper": "^0.6.1",
     "ember-singularity": "^2.0.0",
     "ember-test-selectors": "^6.0.0"
   },

--- a/tests/integration/components/line-clamp-test.js
+++ b/tests/integration/components/line-clamp-test.js
@@ -843,4 +843,43 @@ module('Integration | Component | line clamp', function (hooks) {
       .dom('[data-test-line-clamp-show-more-button]')
       .isFocused('show more button is focused');
   });
+
+  test('tag name is <div> by default', async function (assert) {
+    assert.expect(1);
+
+    await render(hbs`
+      <div style="width: 300px; font-size: 16px; font-family: sans-serif;">
+        <LineClamp
+          @text="helloworld helloworld helloworld"
+        />
+      </div>`);
+
+    const element = this.element;
+    const lineClampElement = element.querySelector('[data-test-line-clamp]');
+    assert.strictEqual(
+      lineClampElement.tagName,
+      'DIV',
+      'line-clamp element is <div>'
+    );
+  });
+
+  test('tag name is able to be changed', async function (assert) {
+    assert.expect(1);
+
+    await render(hbs`
+      <div style="width: 300px; font-size: 16px; font-family: sans-serif;">
+        <LineClamp
+          @text="helloworld helloworld helloworld"
+          @tagName="p"
+        />
+      </div>`);
+
+    const element = this.element;
+    const lineClampElement = element.querySelector('[data-test-line-clamp]');
+    assert.strictEqual(
+      lineClampElement.tagName,
+      'P',
+      'line-clamp element is <p> instead of <div>'
+    );
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1085,7 +1085,7 @@
     lodash "^4.17.21"
     resolve "^1.20.0"
 
-"@embroider/util@^1.6.0":
+"@embroider/util@^0.39.1 || ^0.40.0 || ^0.41.0 || ^1.0.0", "@embroider/util@^1.6.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@embroider/util/-/util-1.9.0.tgz#331c46bdf106c44cb1dd6baaa9030d322c13cfca"
   integrity sha512-9I63iJK6N01OHJafmS/BX0msUkTlmhFMIEmDl/SRNACVi0nS6QfNyTgTTeji1P/DALf6eobg/9t/N4VhS9G9QA==
@@ -3593,7 +3593,7 @@ ember-cli-htmlbars@^5.3.1, ember-cli-htmlbars@^5.7.1:
     strip-bom "^4.0.0"
     walk-sync "^2.2.0"
 
-ember-cli-htmlbars@^6.1.1:
+ember-cli-htmlbars@^6.0.1, ember-cli-htmlbars@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-6.1.1.tgz#f5b588572a5d18ad087560122b8dabc90145173d"
   integrity sha512-DKf2rjzIVw9zWCuFsBGJScrgf5Mz7dSg08Cq+FWFYIxnpssINUbNUoB0NHWnUJK4QqCvaExOyOmjm0kO455CPg==
@@ -3853,6 +3853,15 @@ ember-disable-prototype-extensions@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"
   integrity sha512-SB9NcZ27OtoUk+gfalsc3QU17+54OoqR668qHcuvHByk4KAhGxCKlkm9EBlKJcGr7yceOOAJqohTcCEBqfRw9g==
+
+ember-element-helper@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/ember-element-helper/-/ember-element-helper-0.6.1.tgz#a6fbc5be5f875b5c864ae61bf5c5f81d6de6d936"
+  integrity sha512-YiOdAMlzYul4ulkIoNp8z7iHDfbT1fbut/9xGFRfxDwU/FmF8HtAUB2f1veu/w50HTeZNopa1OV2PCloZ76XlQ==
+  dependencies:
+    "@embroider/util" "^0.39.1 || ^0.40.0 || ^0.41.0 || ^1.0.0"
+    ember-cli-babel "^7.26.11"
+    ember-cli-htmlbars "^6.0.1"
 
 ember-export-application-global@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Previously users were able to modify the tagName used by the LineClamp element, like

```handlebars
<LineClamp
  @text="hello world"
  @lines={{2}}
  @tagName="h3"
/>
```

But that is no longer possible now that this is using `@glimmer/component`.

This adds that functionality back.