### PR TITLE
Remove IE9 target for local transpilation

### DIFF
--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,6 +1,5 @@
 module.exports = {
   browsers: [
-    'ie 9',
     'last 1 Chrome versions',
     'last 1 Firefox versions',
     'last 1 Safari versions',


### PR DESCRIPTION
No need to support such old targets for local dev