### PR TITLE
[A11Y] Fixes axe-core duplicate-id-active error

### DIFF
--- a/addon/components/line-clamp.hbs
+++ b/addon/components/line-clamp.hbs
@@ -21,7 +21,7 @@
                   data-test-line-clamp-show-more-button="true"
                   href="#"
                   role="button"
-                  id="line-clamp-show-more-button"
+                  id="line-clamp-show-more-button-{{this.buttonId}}"
                   aria-expanded="false"
                   aria-label={{@seeMoreA11yText}}
                   class="lt-line-clamp__more"
@@ -47,7 +47,7 @@
         {{#if this._expanded}}
           <span><a
               data-test-line-clamp-show-less-button="true"
-              id="line-clamp-show-less-button"
+              id="line-clamp-show-less-button-{{this.buttonId}}"
               href="#"
               role="button"
               aria-expanded="true"

--- a/addon/components/line-clamp.js
+++ b/addon/components/line-clamp.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
 import { htmlSafe, isHTMLSafe } from '@ember/template';
 import { scheduleOnce } from '@ember/runloop';
 import { debug } from '@ember/debug';
@@ -317,6 +318,12 @@ export default class LineClampComponent extends Component {
     }
     return [];
   }
+
+  /**
+   * Unique identifier used to differentiate between multiple instances.
+   * @type {String}
+   */
+  buttonId = guidFor(this);
 
   constructor() {
     super(...arguments);
@@ -668,7 +675,7 @@ export default class LineClampComponent extends Component {
     if (justExpanded) {
       mutateDOM(() => {
         const showLessButton = this.element.querySelector(
-          '#line-clamp-show-less-button'
+          `#line-clamp-show-less-button-${this.buttonId}`
         );
         if (showLessButton) {
           showLessButton.focus();
@@ -680,7 +687,7 @@ export default class LineClampComponent extends Component {
     } else {
       mutateDOM(() => {
         const showMoreButton = this.element.querySelector(
-          '#line-clamp-show-more-button'
+          `#line-clamp-show-more-button-${this.buttonId}`
         );
         if (showMoreButton) {
           showMoreButton.focus();


### PR DESCRIPTION
Fixes issue #44. Because `ember-line-clamp` uses the same static id attribute across all instances on a page, its generated markup gets identified as a set of accessibility violations when using `axe-core` in tests and in the Accessibility Insights extension. ID attribute duplication is disallowed in the HTML specification and negatively impacts assistive software users, as subsequent instances of the element may end up getting outright ignored by assistive software. The fix generates a unique GUID for the component, which is then subsequently used to add uniqueness to the generated IDs.

## Testing Done
* Tests pass
* Manually verified generated IDs as unique
* Multiple instances pass when using the Accessibility Insights extension